### PR TITLE
New super() style

### DIFF
--- a/kobin/exceptions.py
+++ b/kobin/exceptions.py
@@ -2,4 +2,4 @@
 class HTTPError(Exception):
     def __init__(self, status, message, *args, **kwargs):
         print(status, message)
-        super(HTTPError, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)


### PR DESCRIPTION
super() in Python 3 is equivalent super(HTTPError, self) in Python 2