### PR TITLE
Fix typo and dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     long_description=README + '\n\n' + CHANGES,
     classifiers=__classifiers__,
     packages=find_packages(exclude=['test*']),
-    install_requirements=['jinja2'],
+    install_requires=['jinja2'],
     keywords='web framework wsgi',
     license=__license__,
     include_package_data=True,


### PR DESCRIPTION
Typo causes ImportError and then Jinja2 is not installed.

## Before this PR is merged

```
$ git clone https://github.com/c-bata/kobin.git
$ cd kobin
$ pyvenv venv
$ source venv/bin/activate
$ pip install .

(venv)
$ python
Python 3.5.2 (default, Sep 15 2016, 07:38:42)
[GCC 4.2.1 Compatible Apple LLVM 7.3.0 (clang-703.0.31)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import kobin
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/taku/dev/src/github.com/c-bata/kobin/kobin/__init__.py", line 3, in <module>
    from .templates import render_template
  File "/Users/taku/dev/src/github.com/c-bata/kobin/kobin/templates.py", line 1, in <module>
    from jinja2 import Environment, FileSystemLoader  # type: ignore
ImportError: No module named 'jinja2'
```

## After this PR is merged

```
(venv)
$ python
Python 3.5.2 (default, Sep 15 2016, 07:38:42)
[GCC 4.2.1 Compatible Apple LLVM 7.3.0 (clang-703.0.31)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import kobin
>>>
```